### PR TITLE
[ISSUE-2] Fix crash on iOS 15

### DIFF
--- a/ListKit.xcodeproj/project.pbxproj
+++ b/ListKit.xcodeproj/project.pbxproj
@@ -21,6 +21,7 @@
 /* End PBXAggregateTarget section */
 
 /* Begin PBXBuildFile section */
+		4E687B3326FA268700E7DA32 /* UICollectionViewExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4E687B3226FA268700E7DA32 /* UICollectionViewExtensions.swift */; };
 		4E9AB97226F74BC600A53CBD /* ComponentLifeTimeTrackingDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4E9AB97126F74BC600A53CBD /* ComponentLifeTimeTrackingDelegate.swift */; };
 		4E9AB97426F74BD800A53CBD /* ListKitDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4E9AB97326F74BD800A53CBD /* ListKitDelegate.swift */; };
 		OBJ_102 /* ListKitTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_46 /* ListKitTests.swift */; };
@@ -73,6 +74,7 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		4E687B3226FA268700E7DA32 /* UICollectionViewExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UICollectionViewExtensions.swift; sourceTree = "<group>"; };
 		4E9AB97126F74BC600A53CBD /* ComponentLifeTimeTrackingDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ComponentLifeTimeTrackingDelegate.swift; sourceTree = "<group>"; };
 		4E9AB97326F74BD800A53CBD /* ListKitDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ListKitDelegate.swift; sourceTree = "<group>"; };
 		"ListKit::ListKit::Product" /* ListKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = ListKit.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -172,6 +174,7 @@
 			children = (
 				OBJ_24 /* NSObjectExtensions.swift */,
 				OBJ_25 /* ObjectAssociation.swift */,
+				4E687B3226FA268700E7DA32 /* UICollectionViewExtensions.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -237,7 +240,7 @@
 			name = Products;
 			sourceTree = BUILT_PRODUCTS_DIR;
 		};
-		OBJ_5 /*  */ = {
+		OBJ_5 = {
 			isa = PBXGroup;
 			children = (
 				OBJ_6 /* Package.swift */,
@@ -248,7 +251,6 @@
 				OBJ_51 /* README.md */,
 				OBJ_52 /* build.sh */,
 			);
-			name = "";
 			sourceTree = "<group>";
 		};
 		OBJ_7 /* Sources */ = {
@@ -353,7 +355,7 @@
 			knownRegions = (
 				en,
 			);
-			mainGroup = OBJ_5 /*  */;
+			mainGroup = OBJ_5;
 			productRefGroup = OBJ_47 /* Products */;
 			projectDirPath = "";
 			projectRoot = "";
@@ -389,6 +391,7 @@
 				OBJ_64 /* ComposeLayoutProvider.swift in Sources */,
 				OBJ_65 /* ListKitDataSource.swift in Sources */,
 				OBJ_66 /* DiffableDataSource.swift in Sources */,
+				4E687B3326FA268700E7DA32 /* UICollectionViewExtensions.swift in Sources */,
 				OBJ_67 /* PlainDataSource.swift in Sources */,
 				OBJ_68 /* NSObjectExtensions.swift in Sources */,
 				OBJ_69 /* ObjectAssociation.swift in Sources */,

--- a/Sources/ListKit/Common/ComponentQueryable.swift
+++ b/Sources/ListKit/Common/ComponentQueryable.swift
@@ -15,10 +15,24 @@ public protocol ComponentQueryable: ComposeLayoutProvider {
 
 extension ComponentQueryable {
     public func anyComponent(at indexPath: IndexPath) -> AnyComponent? {
-        return self.layout?.sections[indexPath.section].components[indexPath.item].component
+        guard
+            let layout = self.layout,
+            0 <= indexPath.section, indexPath.section < layout.sections.count,
+            0 <= indexPath.item, indexPath.item < layout.sections[indexPath.section].components.count
+        else {
+            return nil
+        }
+        return layout.sections[indexPath.section].components[indexPath.item].component
     }
 
     public func component<T>(at indexPath: IndexPath, to type: T.Type) -> T? {
-        return self.layout?.sections[indexPath.section].components[indexPath.item].component.to(type)
+        guard
+            let layout = self.layout,
+            0 <= indexPath.section, indexPath.section < layout.sections.count,
+            0 <= indexPath.item, indexPath.item < layout.sections[indexPath.section].components.count
+        else {
+            return nil
+        }
+        return layout.sections[indexPath.section].components[indexPath.item].component.to(type)
     }
 }

--- a/Sources/ListKit/DataSource/DiffableDataSource.swift
+++ b/Sources/ListKit/DataSource/DiffableDataSource.swift
@@ -42,7 +42,7 @@ open class DiffableDataSource: ListKitDataSource {
             }
             
             self.dataSource?.supplementaryViewProvider = { (collectionView, kind, indexPath) in
-                let view = collectionView.dequeueReusableSupplementaryView(ofKind: ListKitReusableView.className, withReuseIdentifier: ListKitReusableView.className, for: indexPath)
+                let view = collectionView.dequeueReusableSupplementaryView(ofKind: kind, withReuseIdentifier: kind, for: indexPath)
                 if let anySupplementaryComponent = SupplementaryComponentManager.shared[kind], let contentView = anySupplementaryComponent.contentView() as? UIView {
                     
                     view.viewWithTag(ListKit.componentContentViewTag)?.removeFromSuperview()

--- a/Sources/ListKit/DataSource/PlainDataSource.swift
+++ b/Sources/ListKit/DataSource/PlainDataSource.swift
@@ -45,7 +45,7 @@ open class PlainDataSource: NSObject, ListKitDataSource, UICollectionViewDataSou
     
     public func collectionView(_ collectionView: UICollectionView, viewForSupplementaryElementOfKind kind: String, at indexPath: IndexPath) -> UICollectionReusableView {
 
-        let view = collectionView.dequeueReusableSupplementaryView(ofKind: ListKitReusableView.className, withReuseIdentifier: ListKitReusableView.className, for: indexPath)
+        let view = collectionView.dequeueReusableSupplementaryView(ofKind: kind, withReuseIdentifier: kind, for: indexPath)
         if let anySupplementaryComponent = SupplementaryComponentManager.shared[kind], let contentView = anySupplementaryComponent.contentView() as? UIView {
             
             view.viewWithTag(ListKit.componentContentViewTag)?.removeFromSuperview()

--- a/Sources/ListKit/Extensions/UICollectionViewExtensions.swift
+++ b/Sources/ListKit/Extensions/UICollectionViewExtensions.swift
@@ -1,0 +1,18 @@
+//
+//  UICollectionViewExtensions.swift
+//  ListKit
+//
+//  Created by burt on 2021/09/21.
+//
+
+import UIKit
+
+extension UICollectionView {
+    /// unregistering supplementary view of kind
+    /// In Apple Docs, You may specify nil for viewClass if you want to unregister the class from the specified element kind and reuse identifier.
+    func unregisterSupplementaryView(kind: String, withReuseIdentifier reuseIdentifier: String) {
+        // need it to prevent Ambiguous use of 'register(_:forSupplementaryViewOfKind:withReuseIdentifier:)'
+        let nilAnyClass: AnyClass? = nil
+        self.register(nilAnyClass, forSupplementaryViewOfKind: kind, withReuseIdentifier: reuseIdentifier)
+    }
+}

--- a/Sources/ListKit/Renderer/Renderer.swift
+++ b/Sources/ListKit/Renderer/Renderer.swift
@@ -81,8 +81,10 @@ public class ComposeRenderer {
     }
     
     public func render(animated: Bool = false, @SectionBuilder sections: () -> [SectionBuilderResult]) {
+        self.unregisterSupplementaryViewsAndClear()
         let compose = ComposeLayout(configuration: configuration, sections: sections)
         self.compose = compose
+        self.registerSupplementaryViews()
         self.dataSource?.layout = self.compose
         self.delegate.layout = self.compose
         self.target?.setCollectionViewLayout(compose.layout, animated: animated)
@@ -90,9 +92,10 @@ public class ComposeRenderer {
     }
     
     public func render<T>(of items: [T], animated: Bool = false, builder: (T) -> NSCollectionLayoutSectionConvertible) {
-        SupplementaryComponentManager.shared.clear()
+        self.unregisterSupplementaryViewsAndClear()
         let compose = ComposeLayout(configuration: configuration, of: items, builder: builder)
         self.compose = compose
+        self.registerSupplementaryViews()
         self.dataSource?.layout = self.compose
         self.delegate.layout = self.compose
         self.target?.setCollectionViewLayout(compose.layout, animated: animated)
@@ -106,6 +109,19 @@ public class ComposeRenderer {
                 diffable.layout = compose
                 diffable.applySnapshot(animated: animated)
             }
+        }
+    }
+    
+    private func unregisterSupplementaryViewsAndClear() {
+        SupplementaryComponentManager.shared.supplementaryComponentMap.keys.forEach { kind in
+            self.target?.unregisterSupplementaryView(kind: kind, withReuseIdentifier: kind)
+        }
+        SupplementaryComponentManager.shared.clear()
+    }
+
+    private func registerSupplementaryViews() {
+        SupplementaryComponentManager.shared.supplementaryComponentMap.keys.forEach { kind in
+            self.target?.register(ListKitReusableView.self, forSupplementaryViewOfKind: kind, withReuseIdentifier: kind)
         }
     }
 }

--- a/Sources/ListKit/Utils/SupplementaryComponentManager.swift
+++ b/Sources/ListKit/Utils/SupplementaryComponentManager.swift
@@ -9,7 +9,7 @@ import Foundation
 
 internal class SupplementaryComponentManager {
     static let shared = SupplementaryComponentManager()
-    private var supplementaryComponentMap: [String: AnySupplementaryComponent] = [:]
+    private(set) var supplementaryComponentMap: [String: AnySupplementaryComponent] = [:]
     var decorationComponents: [AnyClass] = []
     
     private init() {


### PR DESCRIPTION
## Issue

- #2 

## Changes

- [x] fix crash on SupplementaryComponent
- [x] guard range of index path on querying component
- [x] define `func unregisterSupplementaryView(kind: String, withReuseIdentifier reuseIdentifier: String)` extension for UICollectionView
